### PR TITLE
Change URL 

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -21,7 +21,7 @@ var (
 		Short: "SCORE to Humanitec translator",
 		Long: `SCORE is a specification for defining environment agnostic configuration for cloud based workloads.
 This tool creates a Humanitec deployment from the SCORE specification.
-Complete documentation is available at https://score.sh.`,
+Complete documentation is available at https://score.dev`,
 		Version: fmt.Sprintf("%s (build: %s; sha: %s)", version.Version, version.BuildTime, version.GitSHA),
 	}
 )


### PR DESCRIPTION
Change URL to point to correct score documentation. from `score.sh` to `score.dev `