### PR TITLE
Bugfix/routes rendered at correct place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # VS Code workspace configuration
 .vscode/
 
+# Goland workspace configuration
+.idea/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/examples/04-extras/README.md
+++ b/examples/04-extras/README.md
@@ -69,18 +69,6 @@ Output JSON can be used as a payload for the [Create a new Delta](https://api-do
             "type": "dns"
           }
         },
-        "ingress": {
-          "rules": {
-            "externals.dns": {
-              "http": {
-                "/": {
-                  "port": 80,
-                  "type": "prefix"
-                }
-              }
-            }
-          }
-        },
         "profile": "humanitec/default-module",
         "spec": {
           "containers": {
@@ -91,8 +79,20 @@ Output JSON can be used as a payload for the [Create a new Delta](https://api-do
                   "value": "${values.MESSAGE}"
                 }
               },
-              "id": "web-app",
+              "id": "hello",
               "image": "nginx"
+            }
+          },
+          "ingress": {
+            "rules": {
+              "externals.dns": {
+                "http": {
+                  "/": {
+                    "port": 80,
+                    "type": "prefix"
+                  }
+                }
+              }
             }
           },
           "service": {

--- a/internal/humanitec/convert_test.go
+++ b/internal/humanitec/convert_test.go
@@ -274,6 +274,18 @@ func TestScoreConvert(t *testing.T) {
 										},
 									},
 								},
+								"ingress": map[string]interface{}{
+									"rules": map[string]interface{}{
+										"externals.dns": map[string]interface{}{
+											"http": map[string]interface{}{
+												"/": map[string]interface{}{
+													"port": 8080,
+													"type": "prefix",
+												},
+											},
+										},
+									},
+								},
 							},
 							"externals": map[string]interface{}{
 								"data": map[string]interface{}{
@@ -281,18 +293,6 @@ func TestScoreConvert(t *testing.T) {
 								},
 								"db": map[string]interface{}{
 									"type": "postgres",
-								},
-							},
-							"ingress": map[string]interface{}{
-								"rules": map[string]interface{}{
-									"externals.dns": map[string]interface{}{
-										"http": map[string]interface{}{
-											"/": map[string]interface{}{
-												"port": 8080,
-												"type": "prefix",
-											},
-										},
-									},
 								},
 							},
 						},


### PR DESCRIPTION
Bugfix of https://github.com/score-spec/score-humanitec/issues/10

- Moved conversion of routes to the correct place in JSON output
- Adapted tests and also documentation to reflect the correct render
- Tested against current HT version --> generated draft will now create a route in the application and is deployable