### PR TITLE
Custom workload profiles features support

### DIFF
--- a/examples/04-extras/humanitec.yaml
+++ b/examples/04-extras/humanitec.yaml
@@ -1,9 +1,13 @@
 apiVersion: humanitec.org/v1b1
 
-service:
-  routes:
-    http:
-      "/":
-        type: prefix
-        from: ${resources.dns}
-        port: 80
+profile: "humanitec/default-module"
+spec:
+  "labels":
+    "tags.datadoghq.com/env": "${resources.env.DATADOG_ENV}"
+  "ingress":
+    rules:
+      "${resources.dns}":
+        http:
+          "/":
+            type: prefix
+            port: 80

--- a/examples/04-extras/score.yaml
+++ b/examples/04-extras/score.yaml
@@ -22,5 +22,7 @@ resources:
     properties:
       MESSAGE:
         type: string
+      DATADOG_ENV:
+        type: string
   dns:
     type: dns

--- a/internal/humanitec/consts.go
+++ b/internal/humanitec/consts.go
@@ -1,0 +1,5 @@
+package humanitec
+
+const (
+	DefaultWorkloadProfile = "humanitec/default-module"
+)

--- a/internal/humanitec/extensions/types.go
+++ b/internal/humanitec/extensions/types.go
@@ -12,35 +12,27 @@ package extensions
 // YAML example:
 //
 //	apiVersion: humanitec.org/v1b1
-//	service:
-//	  routes:
-//	    http:
-//	      "/":
-//	        from: ${resources.dns}
-//	        type: prefix
-//	        port: 80
+//	profile: "humanitec/default-module"
+//	spec:
+//	  "labels":
+//	    "tags.datadoghq.com/env": "${resources.env.DATADOG_ENV}"
+//	  "ingress":
+//	    rules:
+//	      "${resources.dns}":
+//	        http:
+//	          "/":
+//	            type: prefix
+//	            port: 80
+//	resources:
+//	  db:
+//	    scope: external
+//	  dns:
+//	    scope: shared
 type HumanitecExtensionsSpec struct {
 	ApiVersion string                  `mapstructure:"apiVersion"`
-	Service    HumanitecServiceSpec    `mapstructure:"service"`
+	Profile    string                  `mapstructure:"profile"`
+	Spec       map[string]interface{}  `mapstructure:"spec"`
 	Resources  HumanitecResourcesSpecs `mapstructure:"resources"`
-}
-
-// HumanitecServiceSpec is a workload service specification.
-type HumanitecServiceSpec struct {
-	Routes HumanitecServiceRoutesSpecs `mapstructure:"routes"`
-}
-
-// HumanitecServiceRoutesSpecs is a map of service routes specifications for each network protocol.
-type HumanitecServiceRoutesSpecs map[string]HumanitecServiceRoutePathsSpec
-
-// HumanitecServiceRoutePathsSpec is a map of service routes specifications for each path.
-type HumanitecServiceRoutePathsSpec map[string]HumanitecServiceRoutePathSpec
-
-// HumanitecServiceRoutePathSpec is a service route specification for a single path.
-type HumanitecServiceRoutePathSpec struct {
-	From string `mapstructure:"from"`
-	Type string `mapstructure:"type"`
-	Port int    `mapstructure:"port"`
 }
 
 // HumanitecResourcesSpecs is a map of workload resources specifications.

--- a/internal/humanitec/extensions/yaml_test.go
+++ b/internal/humanitec/extensions/yaml_test.go
@@ -41,29 +41,40 @@ func TestYamlDecode(t *testing.T) {
 ---
 apiVersion: humanitec.org/v1b1
 
-service:
-  routes:
-    http:
-      "/":
-        type: prefix
-        from: ${resources.dns}
-        port: 80
+profile: "test-org/test-module"
+spec:
+  "labels":
+    "tags.datadoghq.com/env": "${resources.env.DATADOG_ENV}"
+  "ingress":
+    rules:
+      "${resources.dns}":
+        http:
+          "/":
+            type: prefix
+            port: 80
 
 resources:
-    db:
-        scope: external
-    dns:
-        scope: shared
+  db:
+    scope: external
+  dns:
+    scope: shared
 `)),
 			Output: HumanitecExtensionsSpec{
 				ApiVersion: "humanitec.org/v1b1",
-				Service: HumanitecServiceSpec{
-					Routes: HumanitecServiceRoutesSpecs{
-						"http": HumanitecServiceRoutePathsSpec{
-							"/": HumanitecServiceRoutePathSpec{
-								From: "${resources.dns}",
-								Type: "prefix",
-								Port: 80,
+				Profile:    "test-org/test-module",
+				Spec: map[string]interface{}{
+					"labels": map[string]interface{}{
+						"tags.datadoghq.com/env": "${resources.env.DATADOG_ENV}",
+					},
+					"ingress": map[string]interface{}{
+						"rules": map[string]interface{}{
+							"${resources.dns}": map[string]interface{}{
+								"http": map[string]interface{}{
+									"/": map[string]interface{}{
+										"type": "prefix",
+										"port": 80,
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Signed-off-by: Eugene Yarshevich <yarshevich@gmail.com>

#### Description
Allows to choose a workload profile and to define additional features in `humanitec.score.yaml` extensions file.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
