### PR TITLE
refactor: use score-humanitec in cmd directory

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ before:
 builds:
   - id: score-humanitec
     binary: score-humanitec
-    main: ./cli
+    main: ./cmd/score-humanitec
     ldflags:
       - -X github.com/score-spec/score-humanitec/internal/version.Version={{ .Version }}
       - -X github.com/score-spec/score-humanitec/internal/version.BuildTime={{ .CommitDate }}

--- a/cmd/score-humanitec/main.go
+++ b/cmd/score-humanitec/main.go
@@ -11,12 +11,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/score-spec/score-humanitec/cli/cmd"
+	"github.com/score-spec/score-humanitec/internal/command"
 )
 
 func main() {
 
-	if err := cmd.Execute(); err != nil {
+	if err := command.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/internal/command/consts.go
+++ b/internal/command/consts.go
@@ -5,7 +5,7 @@ Copyright 2020 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 */
-package cmd
+package command
 
 const (
 	scoreFileDefault      = "./score.yaml"

--- a/internal/command/delta.go
+++ b/internal/command/delta.go
@@ -5,7 +5,7 @@ Copyright 2020 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 */
-package cmd
+package command
 
 import (
 	"context"

--- a/internal/command/draft.go
+++ b/internal/command/draft.go
@@ -5,7 +5,7 @@ Copyright 2020 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 */
-package cmd
+package command
 
 import (
 	"github.com/spf13/cobra"

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -5,7 +5,7 @@ Copyright 2020 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 */
-package cmd
+package command
 
 import (
 	"fmt"

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -5,7 +5,7 @@ Copyright 2020 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 */
-package cmd
+package command
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Signed-off-by: rachfop <prachford@icloud.com>


#### Description
<!--- Describe your changes in detail -->

- Rename `cli` to `cmd/score-compose`

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- With current package management, the final cli name is `cli`, not `score-humanitec`.
- This PR changes the package name, users can install by `go install github.com/score-spec/score-humanitec/cmd/score-humanitec@latest` to get the score-humanitec cli in $GOBIN
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
