### PR TITLE
Rename `workload` resource type into `service`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ![Score](docs/images/logo.svg) Score overview
 
-Score aims to improve developer producticity and experience by reducing the risk of configuration inconsistencies between local and remote environments. It provides developer-centric workload specification (`score.yaml`) which captures a workloads runtime requirements in a platform-agnostic manner.
+Score aims to improve developer productivity and experience by reducing the risk of configuration inconsistencies between local and remote environments. It provides developer-centric workload specification (`score.yaml`) which captures a workloads runtime requirements in a platform-agnostic manner.
 
 The `score.yaml` specification file can be executed against a _Score Implementation CLI_, a conversion tool for application developers to generate environment specific configuration. In combination with environment specific parameters, the CLI tool can run your workload in the target environment by generating a platform-specific configuration file such as `docker-compose.yaml` or a Helm `values.yaml`. Learn more [here](https://github.com/score-spec/spec#-what-is-score).
 

--- a/examples/03-dependencies/README.md
+++ b/examples/03-dependencies/README.md
@@ -38,9 +38,10 @@ resources:
     properties:
       domain:
   backend:
-    type: workload
+    type: service
     properties:
       name:
+      port:
 ```
 
 This example also uses an extensions file, called `humanitec.yaml`, that contains additional hints for `score-humanitec` CLI tool. This information would help the CLI tool to resolve the resources properly.

--- a/examples/03-dependencies/score.yaml
+++ b/examples/03-dependencies/score.yaml
@@ -31,6 +31,7 @@ resources:
     properties:
       domain:
   backend:
-    type: workload
+    type: service
     properties:
       name:
+      port:

--- a/internal/humanitec/convert.go
+++ b/internal/humanitec/convert.go
@@ -160,7 +160,7 @@ func ConvertSpec(name, envID string, spec *score.WorkloadSpec, ext *extensions.H
 	var externals = map[string]interface{}{}
 	for name, res := range spec.Resources {
 		if meta, exists := ext.Resources[name]; !exists || meta.Scope == "" || meta.Scope == "external" {
-			if res.Type != "workload" && res.Type != "environment" {
+			if res.Type != "service" && res.Type != "environment" {
 				externals[name] = map[string]interface{}{
 					"type": res.Type,
 				}

--- a/internal/humanitec/convert_test.go
+++ b/internal/humanitec/convert_test.go
@@ -165,7 +165,7 @@ func TestScoreConvert(t *testing.T) {
 						Variables: map[string]string{
 							"DEBUG":             "${resources.env.DEBUG}",
 							"LOGS_LEVEL":        "${pod.debug.level}",
-							"ORDERS_SERVICE":    "http://${resources.orders.service.name}:${resources.orders.service.port}/api",
+							"ORDERS_SERVICE":    "http://${resources.orders.name}:${resources.orders.port}/api",
 							"CONNECTION_STRING": "postgresql://${resources.db.host}:${resources.db.port}/${resources.db.name}",
 							"DOMAIN_NAME":       "${resources.dns.domain}",
 						},
@@ -217,10 +217,10 @@ func TestScoreConvert(t *testing.T) {
 						},
 					},
 					"orders": {
-						Type: "workload",
+						Type: "service",
 						Properties: map[string]score.ResourcePropertySpec{
-							"service.name": {Required: false},
-							"service.port": {},
+							"name": {Required: false},
+							"port": {},
 						},
 					},
 				},

--- a/internal/humanitec/templates.go
+++ b/internal/humanitec/templates.go
@@ -47,7 +47,7 @@ func buildContext(metadata score.WorkloadMeta, resources score.ResourcesSpecs, e
 		switch res.Type {
 		case "environment":
 			source = "values"
-		case "workload":
+		case "service":
 			source = fmt.Sprintf("modules.%s", resName)
 		default:
 			if resExt, exists := ext[resName]; exists && resExt.Scope == "shared" {
@@ -63,7 +63,14 @@ func buildContext(metadata score.WorkloadMeta, resources score.ResourcesSpecs, e
 			if _, exists := ctx[ref]; exists {
 				return nil, fmt.Errorf("ambiguous property reference '%s'", ref)
 			}
-			ctx[ref] = fmt.Sprintf("${%s.%s}", source, propName)
+			var sourceProp string
+			switch res.Type {
+			case "service":
+				sourceProp = fmt.Sprintf("service.%s", propName)
+			default:
+				sourceProp = propName
+			}
+			ctx[ref] = fmt.Sprintf("${%s.%s}", source, sourceProp)
 		}
 	}
 

--- a/internal/humanitec/templates.go
+++ b/internal/humanitec/templates.go
@@ -50,6 +50,9 @@ func buildContext(metadata score.WorkloadMeta, resources score.ResourcesSpecs, e
 		case "service":
 			source = fmt.Sprintf("modules.%s", resName)
 		default:
+			if res.Type == "workload" {
+				log.Println("Warning: 'workload' is a reserved resource type. Its usage may lead to compatibility issues with future releases of this application.")
+			}
 			if resExt, exists := ext[resName]; exists && resExt.Scope == "shared" {
 				source = fmt.Sprintf("shared.%s", resName)
 			} else {


### PR DESCRIPTION
#### Description

Score spec has renamed `workload` resource type into `service` for a proper abstraction level.

This change also ensures that `service` resource properties are mapped properly to Humanite modules properties.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
