### PR TITLE
No html safe encoding in generated JSON objects

### DIFF
--- a/internal/humanitec_go/client/deltas.go
+++ b/internal/humanitec_go/client/deltas.go
@@ -8,6 +8,7 @@ The Apache Software Foundation (http://www.apache.org/).
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -62,7 +63,10 @@ func (api *apiClient) CreateDelta(ctx context.Context, orgID, appID string, delt
 // UpdateDelta updates an existing Deployment Delta for the orgID and appID with the given deltaID.
 // The Deltas in the request will be combined and applied on top of existing Delta to produce a merged result.
 func (api *apiClient) UpdateDelta(ctx context.Context, orgID string, appID string, deltaID string, deltas []*humanitec.UpdateDeploymentDeltaRequest) (*humanitec.DeploymentDelta, error) {
-	data, err := json.Marshal(deltas)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(deltas)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling payload into JSON: %w", err)
 	}
@@ -76,7 +80,7 @@ func (api *apiClient) UpdateDelta(ctx context.Context, orgID string, appID strin
 			"Content-Type":  "application/json",
 			"Accept":        "application/json",
 		},
-		Body: data,
+		Body: buf.Bytes(),
 	}
 
 	resp, err := api.client.SendWithContext(ctx, req)

--- a/internal/humanitec_go/client/deltas_test.go
+++ b/internal/humanitec_go/client/deltas_test.go
@@ -44,7 +44,12 @@ func TestCreateDelta(t *testing.T) {
 				Metadata: humanitec.DeltaMetadata{EnvID: "test", Name: "Test delta"},
 				Modules: humanitec.ModuleDeltas{
 					Add: map[string]map[string]interface{}{
-						"module-01": {"image": "busybox"},
+						"module-01": {
+							"image": "busybox",
+							"variables": map[string]interface{}{
+								"TEST": "<a>",
+							},
+						},
 					},
 				},
 			},
@@ -53,7 +58,7 @@ func TestCreateDelta(t *testing.T) {
 				"id": "qwe...rty",
 				"metadata": { "env_id": "test", "name": "Test delta" },
 				"modules": { 
-					"add": { "module-01": { "image": "busybox" } }
+					"add": { "module-01": { "image": "busybox", "variables": { "TEST": "<a>" } } }
 				}
 			}`),
 			ExpectedResult: &humanitec.DeploymentDelta{
@@ -61,7 +66,12 @@ func TestCreateDelta(t *testing.T) {
 				Metadata: humanitec.DeltaMetadata{EnvID: "test", Name: "Test delta"},
 				Modules: humanitec.ModuleDeltas{
 					Add: map[string]map[string]interface{}{
-						"module-01": {"image": "busybox"},
+						"module-01": {
+							"image": "busybox",
+							"variables": map[string]interface{}{
+								"TEST": "<a>",
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
#### Description
JSON is used as a messaging structure with the Humanitec API.  The Go JSON encoder escapes certain characters (e.g. `<`, `>`) in  JSON strings.
Switched the JSON encoded to use the `SetEscapeHTML` to false.

#### What does this PR do?
This does not affect the *data* passed between the APIs (as JSON strings are correctly decoded) but it does make users confused when they see their strings changes.



#### Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I've signed off with an email address that matches the commit author.
