### PR TITLE
Fixed build error

### DIFF
--- a/internal/command/delta.go
+++ b/internal/command/delta.go
@@ -39,7 +39,7 @@ func init() {
 	deltaCmd.MarkFlagRequired("env")
 
 	deltaCmd.Flags().StringArrayVarP(&overrideParams, "property", "p", nil, "Overrides selected property value")
-	deltaCmd.Flags().StringVar(&message, "message", "m", messageDefault, "Message")
+	deltaCmd.Flags().StringVarP(&message, "message", "m", messageDefault, "Message")
 
 	deltaCmd.Flags().BoolVar(&deploy, "deploy", false, "Trigger a new delta deployment at the end")
 	deltaCmd.Flags().BoolVar(&retry, "retry", false, "Retry deployments when a deployment is currently in progress")

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -39,7 +39,7 @@ func init() {
 	runCmd.MarkFlagRequired("env")
 
 	runCmd.Flags().StringArrayVarP(&overrideParams, "property", "p", nil, "Overrides selected property value")
-	runCmd.Flags().StringVar(&message, "message", "m", messageDefault, "Message")
+	runCmd.Flags().StringVarP(&message, "message", "m", messageDefault, "Message")
 
 	runCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "DEPRECATED: Disables Score file schema validation.")
 	runCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable diagnostic messages (written to STDERR)")


### PR DESCRIPTION
Fixed build error:

```
internal/command/run.go:42:69: too many arguments in call to runCmd.Flags().StringVar
        have (*string, string, string, string, string)
        want (*string, string, string, string)
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
