### PR TITLE
fix: placeholders not replaced in resource params

### DIFF
--- a/internal/humanitec/convert.go
+++ b/internal/humanitec/convert.go
@@ -233,7 +233,7 @@ func ConvertSpec(name, envID string, spec *score.WorkloadSpec, ext *extensions.H
 						"type": res.Type,
 					}
 					if len(res.Params) > 0 {
-						extRes["params"] = res.Params
+						extRes["params"] = ctx.SubstituteAll(res.Params)
 					}
 					externals[resName] = extRes
 				} else if scope == "shared" {
@@ -242,7 +242,7 @@ func ConvertSpec(name, envID string, spec *score.WorkloadSpec, ext *extensions.H
 						"type": res.Type,
 					}
 					if len(res.Params) > 0 {
-						sharedRes["params"] = res.Params
+						sharedRes["params"] = ctx.SubstituteAll(res.Params)
 					}
 					shared = append(shared, humanitec.UpdateAction{
 						Operation: "add",

--- a/internal/humanitec/convert_test.go
+++ b/internal/humanitec/convert_test.go
@@ -316,6 +316,12 @@ func TestScoreConvert(t *testing.T) {
 						},
 						Type: "some-type",
 					},
+					"route": {
+						Type: "route",
+						Params: map[string]interface{}{
+							"host": "${resources.dns.host}",
+						},
+					},
 				},
 			},
 			Extensions: &extensions.HumanitecExtensionsSpec{
@@ -408,6 +414,12 @@ func TestScoreConvert(t *testing.T) {
 												"version": "1.1",
 											},
 										},
+									},
+								},
+								"route": map[string]interface{}{
+									"type": "route",
+									"params": map[string]interface{}{
+										"host": "${shared.dns.host}",
 									},
 								},
 							},


### PR DESCRIPTION
It is expected that `params` in resourtces undergo placeholder replacement. This PR does this.

#### What does this PR do?
Performs `SubstituteAll` on app parms in resources,



#### Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I've signed off with an email address that matches the commit author.
