### PR TITLE
`deployment`'s `comment` with `--message`

### DIFF
--- a/internal/command/delta.go
+++ b/internal/command/delta.go
@@ -112,7 +112,7 @@ func delta(cmd *cobra.Command, args []string) error {
 		log.Printf("Starting a new deployment for delta '%s'...\n", res.ID)
 		_, err := client.StartDeployment(cmd.Context(), orgID, appID, envID, retry, &ht.StartDeploymentRequest{
 			DeltaID: res.ID,
-			Comment: "Auto-deployment (SCORE)",
+			Comment: message,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
With https://github.com/score-spec/score-humanitec/pull/43 released in https://github.com/score-spec/score-humanitec/releases/tag/0.7.0, the `delta`'s `message` is correct but when using `--deploy` the `deployment`'s comment is still with the default value: `Auto-deployment (SCORE)`. This current PR fix this issue and complete the previous https://github.com/score-spec/score-humanitec/pull/43.