### PR TITLE
Add managed-by score file annotation to the humanitec deployment file.

### DIFF
--- a/internal/command/consts.go
+++ b/internal/command/consts.go
@@ -26,6 +26,7 @@ var (
 	orgID          string
 	appID          string
 	envID          string
+	managedByUrl   string
 
 	overrideParams []string
 	message        string

--- a/internal/command/delta.go
+++ b/internal/command/delta.go
@@ -74,7 +74,7 @@ func delta(cmd *cobra.Command, args []string) error {
 	// Prepare a new deployment
 	//
 	log.Print("Preparing a new deployment...\n")
-	delta, err := humanitec.ConvertSpec(message, envID, spec, ext)
+	delta, err := humanitec.ConvertSpec(message, envID, managedByUrl, spec, ext)
 	if err != nil {
 		return fmt.Errorf("preparing new deployment: %w", err)
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -35,6 +35,7 @@ func init() {
 	runCmd.Flags().StringVarP(&scoreFile, "file", "f", scoreFileDefault, "Source SCORE file")
 	runCmd.Flags().StringVar(&overridesFile, "overrides", overridesFileDefault, "Overrides file")
 	runCmd.Flags().StringVar(&extensionsFile, "extensions", extensionsFileDefault, "Extensions file")
+	runCmd.Flags().StringVar(&managedByUrl, "managed-by", "", "URL of file that is managing the humanitec workload")
 	runCmd.Flags().StringVar(&envID, "env", "", "Environment ID")
 	runCmd.MarkFlagRequired("env")
 
@@ -68,7 +69,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Prepare a new deployment
 	//
 	log.Print("Preparing a new deployment...\n")
-	delta, err := humanitec.ConvertSpec(message, envID, spec, ext)
+	delta, err := humanitec.ConvertSpec(message, envID, managedByUrl, spec, ext)
 	if err != nil {
 		return fmt.Errorf("preparing new deployment: %w", err)
 	}

--- a/internal/humanitec/consts.go
+++ b/internal/humanitec/consts.go
@@ -1,5 +1,8 @@
 package humanitec
 
 const (
-	DefaultWorkloadProfile = "humanitec/default-module"
+	DefaultWorkloadProfile   = "humanitec/default-module"
+	managedBy                = "score-humanitec"
+	managedByAnnotation      = "humanitec.io/managed-by"
+	workloadSourceAnnotation = "humanitec.io/workload-source"
 )

--- a/internal/humanitec/convert.go
+++ b/internal/humanitec/convert.go
@@ -143,10 +143,16 @@ func convertContainerSpec(name string, spec *score.ContainerSpec, context *templ
 }
 
 // ConvertSpec converts SCORE specification into Humanitec deployment delta.
-func ConvertSpec(name, envID string, spec *score.WorkloadSpec, ext *extensions.HumanitecExtensionsSpec) (*humanitec.CreateDeploymentDeltaRequest, error) {
+func ConvertSpec(name, envID string, managedByUrl string, spec *score.WorkloadSpec, ext *extensions.HumanitecExtensionsSpec) (*humanitec.CreateDeploymentDeltaRequest, error) {
 	ctx, err := buildContext(spec.Metadata, spec.Resources, ext.Resources)
 	if err != nil {
 		return nil, fmt.Errorf("preparing context: %w", err)
+	}
+	var annotations = make(map[string]interface{}, 1)
+
+	if managedByUrl != "" {
+		annotations[managedByAnnotation] = managedBy
+		annotations[workloadSourceAnnotation] = managedByUrl
 	}
 
 	var containers = make(map[string]interface{}, len(spec.Containers))
@@ -160,6 +166,9 @@ func ConvertSpec(name, envID string, spec *score.WorkloadSpec, ext *extensions.H
 
 	var workloadSpec = map[string]interface{}{
 		"containers": containers,
+	}
+	if len(annotations) > 0 {
+		workloadSpec["annotations"] = annotations
 	}
 	if len(spec.Service.Ports) > 0 {
 		var ports = map[string]interface{}{}

--- a/internal/humanitec/convert_test.go
+++ b/internal/humanitec/convert_test.go
@@ -108,6 +108,7 @@ func TestScoreConvert(t *testing.T) {
 		Source     *score.WorkloadSpec
 		Extensions *extensions.HumanitecExtensionsSpec
 		Output     *humanitec.CreateDeploymentDeltaRequest
+		ManagedUrl string
 		Error      error
 	}{
 		{
@@ -169,6 +170,7 @@ func TestScoreConvert(t *testing.T) {
 				},
 			},
 			Extensions: &extensions.HumanitecExtensionsSpec{},
+			ManagedUrl: "",
 			Output: &humanitec.CreateDeploymentDeltaRequest{
 				Metadata: humanitec.DeltaMetadata{EnvID: envID, Name: name},
 				Modules: humanitec.ModuleDeltas{
@@ -352,6 +354,7 @@ func TestScoreConvert(t *testing.T) {
 					},
 				},
 			},
+			ManagedUrl: "test.com",
 			Output: &humanitec.CreateDeploymentDeltaRequest{
 				Metadata: humanitec.DeltaMetadata{EnvID: envID, Name: name},
 				Modules: humanitec.ModuleDeltas{
@@ -359,6 +362,10 @@ func TestScoreConvert(t *testing.T) {
 						"test": {
 							"profile": "test-org/test-module",
 							"spec": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"humanitec.io/managed-by":      "score-humanitec",
+									"humanitec.io/workload-source": "test.com",
+								},
 								"containers": map[string]interface{}{
 									"backend": map[string]interface{}{
 										"id": "backend",
@@ -444,7 +451,7 @@ func TestScoreConvert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			res, err := ConvertSpec(name, envID, tt.Source, tt.Extensions)
+			res, err := ConvertSpec(name, envID, tt.ManagedUrl, tt.Source, tt.Extensions)
 
 			if tt.Error != nil {
 				// On Error


### PR DESCRIPTION
Adding a new --managed-by parameter that will inject the annotations:
`"humanitec.io/managed-by":      "score-humanitec"` and
`humanitec.io/workload-source": ${param.value}`
#### Description
The --managed-by parameter, when present, will be fetched, and passed to the humanitec deployment delta. In case the parameter is present, this change will inject the annotations 
`"humanitec.io/managed-by":      "score-humanitec"` and
`humanitec.io/workload-source": ${param.value}` to the humanitec deployment delta.
#### What does this PR do?
Workloads that are managed by score can be manually edited in the humanitec app, and then the manual edit can be overriden with the next deployment. This change gives the user the ability to point to the location which manages the workload, and it will display the user a warning that the workload is managed by score (and will link to the path provided in the parameter)



#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
