### PR TITLE
feat: add managed by score annotation to support humanitec UI warnings

### DIFF
--- a/internal/command/consts.go
+++ b/internal/command/consts.go
@@ -17,15 +17,16 @@ const (
 )
 
 var (
-	scoreFile      string
-	overridesFile  string
-	extensionsFile string
-	uiUrl          string
-	apiUrl         string
-	apiToken       string
-	orgID          string
-	appID          string
-	envID          string
+	scoreFile         string
+	overridesFile     string
+	extensionsFile    string
+	uiUrl             string
+	apiUrl            string
+	apiToken          string
+	orgID             string
+	appID             string
+	envID             string
+	workloadSourceURL string
 
 	overrideParams []string
 	message        string

--- a/internal/command/delta.go
+++ b/internal/command/delta.go
@@ -25,6 +25,7 @@ func init() {
 	deltaCmd.Flags().StringVarP(&scoreFile, "file", "f", scoreFileDefault, "Source SCORE file")
 	deltaCmd.Flags().StringVar(&overridesFile, "overrides", overridesFileDefault, "Overrides file")
 	deltaCmd.Flags().StringVar(&extensionsFile, "extensions", extensionsFileDefault, "Extensions file")
+	deltaCmd.Flags().StringVar(&workloadSourceURL, "workload-source-url", "", "URL of file that is managing the humanitec workload")
 	deltaCmd.Flags().StringVar(&uiUrl, "ui-url", uiUrlDefault, "Humanitec UI")
 	deltaCmd.Flags().StringVar(&apiUrl, "api-url", apiUrlDefault, "Humanitec API endpoint")
 	deltaCmd.Flags().StringVar(&deltaID, "delta", "", "The ID of an existing delta in Humanitec into which to merge the generated delta")
@@ -74,7 +75,7 @@ func delta(cmd *cobra.Command, args []string) error {
 	// Prepare a new deployment
 	//
 	log.Print("Preparing a new deployment...\n")
-	delta, err := humanitec.ConvertSpec(message, envID, spec, ext)
+	delta, err := humanitec.ConvertSpec(message, envID, workloadSourceURL, spec, ext)
 	if err != nil {
 		return fmt.Errorf("preparing new deployment: %w", err)
 	}

--- a/internal/command/draft.go
+++ b/internal/command/draft.go
@@ -15,6 +15,7 @@ func init() {
 	draftCmd.Flags().StringVarP(&scoreFile, "file", "f", scoreFileDefault, "Source SCORE file")
 	draftCmd.Flags().StringVar(&overridesFile, "overrides", overridesFileDefault, "Overrides file")
 	draftCmd.Flags().StringVar(&extensionsFile, "extensions", extensionsFileDefault, "Extensions file")
+	draftCmd.Flags().StringVar(&workloadSourceURL, "workload-source-url", "", "URL of file that is managing the humanitec workload")
 	draftCmd.Flags().StringVar(&uiUrl, "ui-url", uiUrlDefault, "Humanitec API endpoint")
 	draftCmd.Flags().StringVar(&apiUrl, "api-url", apiUrlDefault, "Humanitec API endpoint")
 	draftCmd.Flags().StringVar(&apiToken, "token", "", "Humanitec API authentication token")

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -35,6 +35,7 @@ func init() {
 	runCmd.Flags().StringVarP(&scoreFile, "file", "f", scoreFileDefault, "Source SCORE file")
 	runCmd.Flags().StringVar(&overridesFile, "overrides", overridesFileDefault, "Overrides file")
 	runCmd.Flags().StringVar(&extensionsFile, "extensions", extensionsFileDefault, "Extensions file")
+	runCmd.Flags().StringVar(&workloadSourceURL, "workload-source-url", "", "URL of file that is managing the humanitec workload")
 	runCmd.Flags().StringVar(&envID, "env", "", "Environment ID")
 	runCmd.MarkFlagRequired("env")
 
@@ -68,7 +69,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Prepare a new deployment
 	//
 	log.Print("Preparing a new deployment...\n")
-	delta, err := humanitec.ConvertSpec(message, envID, spec, ext)
+	delta, err := humanitec.ConvertSpec(message, envID, workloadSourceURL, spec, ext)
 	if err != nil {
 		return fmt.Errorf("preparing new deployment: %w", err)
 	}

--- a/internal/humanitec/consts.go
+++ b/internal/humanitec/consts.go
@@ -1,5 +1,8 @@
 package humanitec
 
 const (
-	DefaultWorkloadProfile = "humanitec/default-module"
+	DefaultWorkloadProfile   = "humanitec/default-module"
+	managedBy                = "score-humanitec"
+	managedByAnnotation      = "humanitec.io/managed-by"
+	workloadSourceAnnotation = "humanitec.io/workload-source"
 )

--- a/internal/humanitec/convert.go
+++ b/internal/humanitec/convert.go
@@ -143,10 +143,16 @@ func convertContainerSpec(name string, spec *score.ContainerSpec, context *templ
 }
 
 // ConvertSpec converts SCORE specification into Humanitec deployment delta.
-func ConvertSpec(name, envID string, spec *score.WorkloadSpec, ext *extensions.HumanitecExtensionsSpec) (*humanitec.CreateDeploymentDeltaRequest, error) {
+func ConvertSpec(name, envID string, workloadSourceURL string, spec *score.WorkloadSpec, ext *extensions.HumanitecExtensionsSpec) (*humanitec.CreateDeploymentDeltaRequest, error) {
 	ctx, err := buildContext(spec.Metadata, spec.Resources, ext.Resources)
 	if err != nil {
 		return nil, fmt.Errorf("preparing context: %w", err)
+	}
+	annotations := map[string]interface{}{
+		managedByAnnotation: managedBy,
+	}
+	if workloadSourceURL != "" {
+		annotations[workloadSourceAnnotation] = workloadSourceURL
 	}
 
 	var containers = make(map[string]interface{}, len(spec.Containers))
@@ -159,7 +165,8 @@ func ConvertSpec(name, envID string, spec *score.WorkloadSpec, ext *extensions.H
 	}
 
 	var workloadSpec = map[string]interface{}{
-		"containers": containers,
+		"annotations": annotations,
+		"containers":  containers,
 	}
 	if len(spec.Service.Ports) > 0 {
 		var ports = map[string]interface{}{}

--- a/internal/humanitec/convert_test.go
+++ b/internal/humanitec/convert_test.go
@@ -104,11 +104,12 @@ func TestScoreConvert(t *testing.T) {
 	)
 
 	var tests = []struct {
-		Name       string
-		Source     *score.WorkloadSpec
-		Extensions *extensions.HumanitecExtensionsSpec
-		Output     *humanitec.CreateDeploymentDeltaRequest
-		Error      error
+		Name              string
+		Source            *score.WorkloadSpec
+		Extensions        *extensions.HumanitecExtensionsSpec
+		Output            *humanitec.CreateDeploymentDeltaRequest
+		WorkloadSourceURL string
+		Error             error
 	}{
 		{
 			Name: "Should convert SCORE to deployment delta",
@@ -168,7 +169,8 @@ func TestScoreConvert(t *testing.T) {
 					},
 				},
 			},
-			Extensions: &extensions.HumanitecExtensionsSpec{},
+			Extensions:        &extensions.HumanitecExtensionsSpec{},
+			WorkloadSourceURL: "",
 			Output: &humanitec.CreateDeploymentDeltaRequest{
 				Metadata: humanitec.DeltaMetadata{EnvID: envID, Name: name},
 				Modules: humanitec.ModuleDeltas{
@@ -176,6 +178,9 @@ func TestScoreConvert(t *testing.T) {
 						"backend": {
 							"profile": "humanitec/default-module",
 							"spec": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"humanitec.io/managed-by": "score-humanitec",
+								},
 								"containers": map[string]interface{}{
 									"backend": map[string]interface{}{
 										"id":    "backend",
@@ -352,6 +357,7 @@ func TestScoreConvert(t *testing.T) {
 					},
 				},
 			},
+			WorkloadSourceURL: "https://test.com",
 			Output: &humanitec.CreateDeploymentDeltaRequest{
 				Metadata: humanitec.DeltaMetadata{EnvID: envID, Name: name},
 				Modules: humanitec.ModuleDeltas{
@@ -359,6 +365,10 @@ func TestScoreConvert(t *testing.T) {
 						"test": {
 							"profile": "test-org/test-module",
 							"spec": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"humanitec.io/managed-by":      "score-humanitec",
+									"humanitec.io/workload-source": "https://test.com",
+								},
 								"containers": map[string]interface{}{
 									"backend": map[string]interface{}{
 										"id": "backend",
@@ -444,7 +454,7 @@ func TestScoreConvert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			res, err := ConvertSpec(name, envID, tt.Source, tt.Extensions)
+			res, err := ConvertSpec(name, envID, tt.WorkloadSourceURL, tt.Source, tt.Extensions)
 
 			if tt.Error != nil {
 				// On Error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add a `"humanitec.io/managed-by": "score-humanitec"` annotation to signal that workloads are managed by score and not inside the Humanitec UI.

Additionally add a new `--workload-source-url` parameter that allows link to the score file so developers can quickly find the file.

#### Description
<!--- Describe your changes in detail -->

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Workloads that are managed by score can be manually edited in the humanitec app, and then the manual edit can be overridden with the next deployment. This change gives the user the ability to point to the location which manages the workload, and it will display the user a warning that the workload is managed by score (and will link to the path provided in the parameter)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
