### PR TITLE
Improved humanitec error handling

### DIFF
--- a/internal/command/delta.go
+++ b/internal/command/delta.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/score-spec/score-humanitec/internal/humanitec"
 	api "github.com/score-spec/score-humanitec/internal/humanitec_go/client"
@@ -74,6 +75,11 @@ func delta(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Validate the ID
+	if err := validateIDs(); err != nil {
+		return err
+	}
+
 	// Prepare a new deployment
 	//
 	log.Print("Preparing a new deployment...\n")
@@ -119,6 +125,25 @@ func delta(cmd *cobra.Command, args []string) error {
 		})
 		if err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+var validID = regexp.MustCompile(`^[a-z0-9](?:-?[a-z0-9]+)+$`)
+
+func validateIDs() error {
+	ids := []struct {
+		name string
+		id   string
+	}{
+		{"organization", orgID}, {"application", appID}, {"environment", envID},
+	}
+
+	for _, e := range ids {
+		if !validID.MatchString(e.id) {
+			return fmt.Errorf("invalid %s id '%s'. Did you use the %s name instead of the id?", e.name, e.id, e.name)
 		}
 	}
 

--- a/internal/humanitec_go/client/deltas.go
+++ b/internal/humanitec_go/client/deltas.go
@@ -57,7 +57,7 @@ func (api *apiClient) CreateDelta(ctx context.Context, orgID, appID string, delt
 		}
 
 	default:
-		return nil, fmt.Errorf("humanitec api: %s %s: HTTP %d - %s", req.Method, req.BaseURL, resp.StatusCode, http.StatusText(resp.StatusCode))
+		return nil, resError(req, resp)
 	}
 }
 
@@ -100,6 +100,10 @@ func (api *apiClient) UpdateDelta(ctx context.Context, orgID string, appID strin
 			return &res, nil
 		}
 	default:
-		return nil, fmt.Errorf("humanitec api: %s %s: HTTP %d - %s", req.Method, req.BaseURL, resp.StatusCode, http.StatusText(resp.StatusCode))
+		return nil, resError(req, resp)
 	}
+}
+
+func resError(req rest.Request, resp *rest.Response) error {
+	return fmt.Errorf("humanitec api: %s %s: unexpected response status %d - %s\n%s", req.Method, req.BaseURL, resp.StatusCode, http.StatusText(resp.StatusCode), resp.Body)
 }

--- a/internal/humanitec_go/client/deltas_test.go
+++ b/internal/humanitec_go/client/deltas_test.go
@@ -87,7 +87,8 @@ func TestCreateDelta(t *testing.T) {
 		{
 			Name:          "Should handle API errors",
 			StatusCode:    http.StatusInternalServerError,
-			ExpectedError: errors.New("HTTP 500"),
+			ExpectedError: errors.New("unexpected response status 500 - Internal Server Error\nerror details"),
+			Response:      []byte(`error details`),
 		},
 		{
 			Name:          "Should handle response parsing errors",
@@ -208,6 +209,7 @@ func TestUpdateDelta_fail(t *testing.T) {
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("{\"error\": \"Not Found\"}"))
 			},
 		),
 	)
@@ -219,5 +221,5 @@ func TestUpdateDelta_fail(t *testing.T) {
 		{Modules: humanitec.ModuleDeltas{}},
 	})
 	assert.Nil(t, res)
-	assert.ErrorContains(t, err, ": HTTP 404 - Not Found")
+	assert.ErrorContains(t, err, ": unexpected response status 404 - Not Found\n{\"error\": \"Not Found\"}")
 }

--- a/internal/humanitec_go/client/deployments.go
+++ b/internal/humanitec_go/client/deployments.go
@@ -67,6 +67,6 @@ func (api *apiClient) StartDeployment(ctx context.Context, orgID, appID, envID s
 
 		fallthrough
 	default:
-		return nil, fmt.Errorf("humanitec api: %s %s: HTTP %d - %s", req.Method, req.BaseURL, resp.StatusCode, http.StatusText(resp.StatusCode))
+		return nil, resError(req, resp)
 	}
 }

--- a/internal/humanitec_go/client/deployments_test.go
+++ b/internal/humanitec_go/client/deployments_test.go
@@ -83,7 +83,8 @@ func TestStartDeployment(t *testing.T) {
 		{
 			Name:          "Should handle API errors",
 			StatusCode:    []int{http.StatusInternalServerError},
-			ExpectedError: errors.New("HTTP 500"),
+			Response:      []byte(`error details`),
+			ExpectedError: errors.New("unexpected response status 500 - Internal Server Error\nerror details"),
 		},
 		{
 			Name:          "Should handle response parsing errors",
@@ -99,7 +100,8 @@ func TestStartDeployment(t *testing.T) {
 			},
 			Retry:         false,
 			StatusCode:    []int{http.StatusConflict},
-			ExpectedError: errors.New("HTTP 409"),
+			Response:      []byte(`conflict details`),
+			ExpectedError: errors.New("unexpected response status 409 - Conflict\nconflict details"),
 		},
 		{
 			Name: "Should retry conflict errors with retry",

--- a/internal/humanitec_go/client/resources.go
+++ b/internal/humanitec_go/client/resources.go
@@ -48,6 +48,6 @@ func (api *apiClient) ListResourceTypes(ctx context.Context, orgID string) ([]hu
 		}
 
 	default:
-		return nil, fmt.Errorf("humanitec api: %s %s: HTTP %d - %s", req.Method, req.BaseURL, resp.StatusCode, http.StatusText(resp.StatusCode))
+		return nil, resError(req, resp)
 	}
 }

--- a/internal/humanitec_go/client/resources_test.go
+++ b/internal/humanitec_go/client/resources_test.go
@@ -88,7 +88,8 @@ func TestListResourceTypes(t *testing.T) {
 		{
 			Name:          "Should handle API errors",
 			StatusCode:    http.StatusInternalServerError,
-			ExpectedError: errors.New("HTTP 500"),
+			ExpectedError: errors.New("unexpected response status 500 - Internal Server Error\nerror details"),
+			Response:      []byte(`error details`),
 		},
 		{
 			Name:          "Should handle response parsing errors",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Improved error handling by validating the provided IDs locally and by including the returned API response in error messages.

Fixes https://github.com/score-spec/score-humanitec/issues/63

#### Description
<!--- Describe your changes in detail -->

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users often mixup name and id, to prevent confusion the id is validated locally.

Additionally API error messages are now included in the output as those often provide more details how to resolve an issue.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
