### PR TITLE
fix: add immage flag for . image convention

### DIFF
--- a/internal/command/consts.go
+++ b/internal/command/consts.go
@@ -29,6 +29,7 @@ var (
 	workloadSourceURL string
 
 	overrideParams []string
+	currentImage   string
 	message        string
 
 	// deltaID is a cli flag receiver used to support "score-humanitec delta --use foo"

--- a/internal/command/delta.go
+++ b/internal/command/delta.go
@@ -42,6 +42,7 @@ func init() {
 	deltaCmd.MarkFlagRequired("env")
 
 	deltaCmd.Flags().StringArrayVarP(&overrideParams, "property", "p", nil, "Overrides selected property value")
+	deltaCmd.Flags().StringVarP(&currentImage, "image", "i", ".", "Image to use for the current image, signified by \".\"")
 	deltaCmd.Flags().StringVarP(&message, "message", "m", messageDefault, "Message")
 
 	deltaCmd.Flags().BoolVar(&deploy, "deploy", false, "Trigger a new delta deployment at the end")

--- a/internal/command/draft.go
+++ b/internal/command/draft.go
@@ -28,6 +28,7 @@ func init() {
 	draftCmd.MarkFlagRequired("env")
 
 	draftCmd.Flags().StringArrayVarP(&overrideParams, "property", "p", nil, "Overrides selected property value")
+	draftCmd.Flags().StringVarP(&currentImage, "image", "i", ".", "Image to use for the current image, signified by \".\"")
 
 	draftCmd.Flags().BoolVar(&deploy, "deploy", false, "Trigger a new draft deployment at the end")
 	draftCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable diagnostic messages (written to STDERR)")


### PR DESCRIPTION
Add `-i|--image` flag to allow for specifying the image to override when the `image` property in a score file has a value `.`

#### Description
- Added a new Flag to all commands
- Added a backwards compatible implementation to override `.containers.{containerId}.image` where the value is `.`

#### What does this PR do?
It is a convention when working with score that setting the image to `.` means: "the image in the current context". Usually, this means the image that is associated with the score file. The CI pipeline will know the generated image to be inserted.

Today, there are a number of workarounds involving `--property` overrides (which require knowledge of the container IDs) or even `sed` scripts such as:
```
sed -i -E "s/^(\\s+image:)\\s+.*\$/\\1 '${IMAGE_NAME}'/" score.yaml
```

This change will make updated in the current image much simpler:

```
score-humanitec delta -i my-image:my-tag --org....
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
