### PR TITLE
fix: update score-go to 1.1.0 and update go to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,14 @@
 module github.com/score-spec/score-humanitec
 
-go 1.19
+go 1.22
+
+toolchain go1.22.0
 
 require (
 	github.com/golang/mock v1.6.0
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/score-spec/score-go v0.0.0-20231024094556-308a07ae2536
+	github.com/score-spec/score-go v1.1.0
 	github.com/sendgrid/rest v2.6.9+incompatible
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -15,12 +15,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v0.0.0-20230905115428-131acdd2f5cf h1:0Dt+qyYoGTXPPU5Xq/KxLDtQMMA8hX+oJ8EsjFWUajQ=
-github.com/score-spec/score-go v0.0.0-20230905115428-131acdd2f5cf/go.mod h1:3l9mvrtYKzxXDQVcYkQBD3ABTPkTzWhUMYNfGlpctoo=
-github.com/score-spec/score-go v0.0.0-20231024093959-ed5a5d548352 h1:yycML7iVHv/65wo4ao7uH5cvIYgQhB184iKAy7suNBk=
-github.com/score-spec/score-go v0.0.0-20231024093959-ed5a5d548352/go.mod h1:3l9mvrtYKzxXDQVcYkQBD3ABTPkTzWhUMYNfGlpctoo=
-github.com/score-spec/score-go v0.0.0-20231024094556-308a07ae2536 h1:WBWWWSbAR2oJapUZyCm4IZ5LJfkT5IUlHtmcJNBLFiY=
-github.com/score-spec/score-go v0.0.0-20231024094556-308a07ae2536/go.mod h1:3l9mvrtYKzxXDQVcYkQBD3ABTPkTzWhUMYNfGlpctoo=
+github.com/score-spec/score-go v1.1.0 h1:63WM1u93NtGgMuPtVZ/UBfzg/BpYuY8sBquaL0BkrXU=
+github.com/score-spec/score-go v1.1.0/go.mod h1:nt6TOq2Ld9SiH3Fd9NF8tiJ9L7S17OE3FNgCrSet5GQ=
 github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
 github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
 github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=

--- a/internal/humanitec/ref.go
+++ b/internal/humanitec/ref.go
@@ -1,0 +1,12 @@
+package humanitec
+
+func Ref[k any](input k) *k {
+	return &input
+}
+
+func DerefOr[k any](input *k, def k) k {
+	if input == nil {
+		return def
+	}
+	return *input
+}

--- a/internal/humanitec/templates_test.go
+++ b/internal/humanitec/templates_test.go
@@ -17,21 +17,21 @@ import (
 )
 
 func TestMapVar(t *testing.T) {
-	var meta = score.WorkloadMeta{
-		Name: "test-name",
+	var meta = score.WorkloadMetadata{
+		"name": "test-name",
 	}
 
-	var resources = score.ResourcesSpecs{
-		"env": score.ResourceSpec{
+	var resources = score.WorkloadResources{
+		"env": score.Resource{
 			Type: "environment",
 		},
-		"db": score.ResourceSpec{
+		"db": score.Resource{
 			Type: "postgres",
 		},
-		"dns": score.ResourceSpec{
+		"dns": score.Resource{
 			Type: "dns",
 		},
-		"service-a": score.ResourceSpec{
+		"service-a": score.Resource{
 			Type: "service",
 		},
 	}
@@ -65,21 +65,21 @@ func TestMapVar(t *testing.T) {
 }
 
 func TestEscape(t *testing.T) {
-	var meta = score.WorkloadMeta{
-		Name: "test-name",
+	var meta = score.WorkloadMetadata{
+		"name": "test-name",
 	}
 
-	var resources = score.ResourcesSpecs{
-		"env": score.ResourceSpec{
+	var resources = score.WorkloadResources{
+		"env": score.Resource{
 			Type: "environment",
 		},
-		"db": score.ResourceSpec{
+		"db": score.Resource{
 			Type: "postgres",
 		},
-		"dns": score.ResourceSpec{
+		"dns": score.Resource{
 			Type: "dns",
 		},
-		"service-a": score.ResourceSpec{
+		"service-a": score.Resource{
 			Type: "service",
 		},
 	}
@@ -109,36 +109,36 @@ func TestEscape(t *testing.T) {
 }
 
 func TestSubstitute(t *testing.T) {
-	var meta = score.WorkloadMeta{
-		Name: "test-name",
+	var meta = score.WorkloadMetadata{
+		"name": "test-name",
 	}
 
-	var resources = score.ResourcesSpecs{
-		"env": score.ResourceSpec{
+	var resources = score.WorkloadResources{
+		"env": score.Resource{
 			Type: "environment",
 		},
-		"db": score.ResourceSpec{
+		"db": score.Resource{
 			Type: "postgres",
 		},
-		"dns": score.ResourceSpec{
+		"dns": score.Resource{
 			Type: "dns",
 		},
-		"service-a": score.ResourceSpec{
+		"service-a": score.Resource{
 			Type: "service",
 		},
-		"shared-res": score.ResourceSpec{
+		"shared-res": score.Resource{
 			Type: "s3",
-			Metadata: score.ResourceMeta{
-				Annotations: map[string]string{
+			Metadata: score.ResourceMetadata{
+				"annotations": map[string]interface{}{
 					AnnotationLabelResourceId: "shared.main-s3",
 				},
 			},
 		},
-		"shared-res-admin": score.ResourceSpec{
+		"shared-res-admin": score.Resource{
 			Type:  "s3",
-			Class: "admin",
-			Metadata: score.ResourceMeta{
-				Annotations: map[string]string{
+			Class: Ref("admin"),
+			Metadata: score.ResourceMetadata{
+				"annotations": map[string]interface{}{
 					AnnotationLabelResourceId: "shared.main-s3",
 				},
 			},
@@ -173,21 +173,21 @@ func TestSubstitute(t *testing.T) {
 }
 
 func TestSubstituteAll(t *testing.T) {
-	var meta = score.WorkloadMeta{
-		Name: "test-name",
+	var meta = score.WorkloadMetadata{
+		"name": "test-name",
 	}
 
-	var resources = score.ResourcesSpecs{
-		"env": score.ResourceSpec{
+	var resources = score.WorkloadResources{
+		"env": score.Resource{
 			Type: "environment",
 		},
-		"db": score.ResourceSpec{
+		"db": score.Resource{
 			Type: "postgres",
 		},
-		"dns": score.ResourceSpec{
+		"dns": score.Resource{
 			Type: "dns",
 		},
-		"service-a": score.ResourceSpec{
+		"service-a": score.Resource{
 			Type: "service",
 		},
 	}


### PR DESCRIPTION
This PR updates score-humanitec to score-go 1.1.0 with the generated types. This is the bulk of the change and causes some things to now be pointers or no longer be pointers. We bump to go 1.22 as well just to keep this up to date (separate dependency updates should be done elsewhere).

Behavior should be much the same as before. Generating the delta from schema/samples/score-full.yaml gives the following:

```
{
  "id": "<snip>",
  "metadata": {
    "env_id": "development",
    "name": "Auto-deployment (SCORE)",
    "url": "<snip>",
    "created_by": "<snip>",
    "created_at": "2024-02-27T15:53:41.259850885Z",
    "last_modified_at": "2024-02-27T15:53:41.259850885Z"
  },
  "modules": {
    "add": {
      "example-workload-name123": {
        "externals": {
          "resource-one1": {
            "class": "default",
            "params": {
              "extra": {
                "data": "here"
              }
            },
            "type": "Resource-One"
          },
          "resource-two2": {
            "class": "default",
            "type": "Resource-Two"
          }
        },
        "profile": "humanitec/default-module",
        "spec": {
          "annotations": {
            "humanitec.io/managed-by": "score-humanitec"
          },
          "containers": {
            "container-one1": {
              "args": [
                "hello",
                "world"
              ],
              "command": [
                "/bin/sh",
                "-c"
              ],
              "files": {
                "/my/other/file": {
                  "mode": "",
                  "value": "some multiline\ncontent\n"
                }
              },
              "id": "container-one1",
              "image": "localhost:4000/repo/my-image:tag",
              "liveness_probe": {
                "path": "/livez",
                "port": 8080,
                "type": "http"
              },
              "readiness_probe": {
                "headers": {
                  "SOME_HEADER": "some-value-here"
                },
                "path": "/readyz",
                "port": 80,
                "type": "http"
              },
              "resources": {
                "limits": {
                  "cpu": "0.24",
                  "memory": "128M"
                },
                "requests": {
                  "cpu": "1000m",
                  "memory": "10Gi"
                }
              },
              "variables": {
                "SOME_VAR": "some content here"
              },
              "volume_mounts": {
                "/mnt/something": {
                  "id": "volume-name",
                  "read_only": false,
                  "sub_path": "/sub/path"
                },
                "/mnt/something-else": {
                  "id": "volume-two",
                  "read_only": false,
                  "sub_path": ""
                }
              }
            },
            "container-two2": {
              "id": "container-two2",
              "image": "."
            }
          },
          "service": {
            "ports": {
              "port-one": {
                "container_port": 10000,
                "protocol": "TCP",
                "service_port": 1000
              },
              "port-two2": {
                "container_port": 8000,
                "protocol": "TCP",
                "service_port": 8000
              }
            }
          }
        }
      }
    }
  }
}
```